### PR TITLE
feat: Wetterwarnungen-Abo (Basislogik + Tests)

### DIFF
--- a/src/wetterwarnungen.js
+++ b/src/wetterwarnungen.js
@@ -1,0 +1,105 @@
+// src/wetterwarnungen.js
+
+/**
+ * Klasse zur Verwaltung von Wetterwarnungs-Abonnements (in-memory).
+ * Später kann Persistenz (DB/API) ergänzt werden.
+ */
+export class WetterWarnungen {
+  constructor() {
+    /** @type {{ email: string, regionen: string[] }[]} */
+    this.abonnements = [];
+  }
+
+  /** Primitive E-Mail-Validierung */
+  static #isValidEmail(email) {
+    if (typeof email !== "string") return false;
+    const trimmed = email.trim();
+    const re = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/i;
+    return re.test(trimmed);
+  }
+
+  /** Regionen normalisieren (trim, lowercase, unique) */
+  static #normalizeRegionen(regionen) {
+    if (!Array.isArray(regionen)) {
+      throw new TypeError("regionen muss ein Array von Strings sein.");
+    }
+    const cleaned = regionen
+      .map((r) => (typeof r === "string" ? r.trim() : ""))
+      .filter((r) => r.length > 0)
+      .map((r) => r.toLowerCase());
+    return [...new Set(cleaned)];
+  }
+
+  /** Neues Abo hinzufügen oder erweitern */
+  abonnieren(email, regionen) {
+    if (!WetterWarnungen.#isValidEmail(email)) {
+      throw new Error("Ungültige E-Mail-Adresse.");
+    }
+    const norm = WetterWarnungen.#normalizeRegionen(regionen);
+    if (norm.length === 0) {
+      throw new Error("Mindestens eine gültige Region angeben.");
+    }
+
+    const idx = this.abonnements.findIndex(
+      (a) => a.email.toLowerCase() === email.toLowerCase()
+    );
+
+    if (idx === -1) {
+      this.abonnements.push({ email: email.trim(), regionen: norm });
+    } else {
+      const merged = [...new Set([...this.abonnements[idx].regionen, ...norm])];
+      this.abonnements[idx].regionen = merged;
+    }
+  }
+
+  /** Alle Abos zurückgeben */
+  getAbonnements() {
+    return this.abonnements.map((a) => ({
+      email: a.email,
+      regionen: [...a.regionen],
+    }));
+  }
+
+  /** Abo nach E-Mail finden */
+  findByEmail(email) {
+    if (!WetterWarnungen.#isValidEmail(email)) return null;
+    const found = this.abonnements.find(
+      (a) => a.email.toLowerCase() === email.toLowerCase()
+    );
+    return found ? { email: found.email, regionen: [...found.regionen] } : null;
+  }
+
+  /** Regionen eines Abos ersetzen */
+  updateRegionen(email, regionen) {
+    if (!WetterWarnungen.#isValidEmail(email)) {
+      throw new Error("Ungültige E-Mail-Adresse.");
+    }
+    const idx = this.abonnements.findIndex(
+      (a) => a.email.toLowerCase() === email.toLowerCase()
+    );
+    if (idx === -1) throw new Error("Abo nicht gefunden.");
+    this.abonnements[idx].regionen = WetterWarnungen.#normalizeRegionen(regionen);
+  }
+
+  /** Abo abmelden (löschen) */
+  abmelden(email) {
+    if (!WetterWarnungen.#isValidEmail(email)) {
+      throw new Error("Ungültige E-Mail-Adresse.");
+    }
+    this.abonnements = this.abonnements.filter(
+      (a) => a.email.toLowerCase() !== email.toLowerCase()
+    );
+  }
+
+  /** Anzahl der Abos */
+  size() {
+    return this.abonnements.length;
+  }
+
+  /** Alle Abos löschen (z. B. für Tests) */
+  clear() {
+    this.abonnements = [];
+  }
+}
+
+export default WetterWarnungen;

--- a/tests/wetterwarnungen.test.js
+++ b/tests/wetterwarnungen.test.js
@@ -1,0 +1,49 @@
+// tests/wetterwarnungen.test.js
+import { describe, it, expect, beforeEach } from "vitest";
+import { WetterWarnungen } from "../src/wetterwarnungen.js";
+
+describe("WetterWarnungen", () => {
+  let ww;
+
+  beforeEach(() => {
+    ww = new WetterWarnungen();
+  });
+
+  it("legt ein neues Abo an", () => {
+    ww.abonnieren("user@example.com", ["Berlin", "Münster"]);
+    expect(ww.size()).toBe(1);
+    const a = ww.findByEmail("user@example.com");
+    expect(a).not.toBeNull();
+    expect(a.regionen.sort()).toEqual(["berlin", "münster"].sort());
+  });
+
+  it("merged Regionen idempotent", () => {
+    ww.abonnieren("u@e.com", ["Berlin"]);
+    ww.abonnieren("u@e.com", ["berlin", "Hamburg"]);
+    const a = ww.findByEmail("u@e.com");
+    expect(a.regionen.sort()).toEqual(["berlin", "hamburg"].sort());
+  });
+
+  it("wirft bei ungültiger E-Mail", () => {
+    expect(() => ww.abonnieren("keine-mail", ["Berlin"])).toThrow();
+  });
+
+  it("wirft bei leeren Regionen", () => {
+    expect(() => ww.abonnieren("a@b.de", [])).toThrow();
+    expect(() => ww.abonnieren("a@b.de", ["   "])).toThrow();
+  });
+
+  it("aktualisiert Regionen strikt", () => {
+    ww.abonnieren("x@y.de", ["berlin"]);
+    ww.updateRegionen("x@y.de", ["hamburg"]);
+    const a = ww.findByEmail("x@y.de");
+    expect(a.regionen).toEqual(["hamburg"]);
+  });
+
+  it("löscht ein Abo", () => {
+    ww.abonnieren("del@me.de", ["berlin"]);
+    ww.abmelden("del@me.de");
+    expect(ww.findByEmail("del@me.de")).toBeNull();
+    expect(ww.size()).toBe(0);
+  });
+});


### PR DESCRIPTION
### Was ist neu?
- In-Memory Verwaltung von Wetterwarnungs-Abonnements
- API: abonnieren, getAbonnements, findByEmail, updateRegionen, abmelden, size, clear
- Normalisierung/Validierung (E-Mail/Regionen)
- Vitest-Tests

### Wie getestet?
- `npm test` lokal ausgeführt (alle Tests green)
- Edge Cases: ungültige E-Mail, leere/duplizierte Regionen

### Breaking Changes?
- Keine

### Nächste Schritte
- Persistenz-Layer (DB/API)
- Integration ins UI (Form für E-Mail + Regionen-Auswahl)
